### PR TITLE
Remove broken XML since 1.15.5 (SoD)

### DIFF
--- a/Ui/ButtonMenu.xml
+++ b/Ui/ButtonMenu.xml
@@ -20,18 +20,6 @@
       <OnLoad function="ItemAutocompleteButtonMenuOnLoad" />
     </Scripts>
 
-    <Backdrop bgFile="Interface\DialogFrame\UI-DialogBox-Background-Dark" edgeFile="Interface\Tooltips\UI-Tooltip-Border" tile="true">
-      <BackgroundInsets>
-        <AbsInset left="5" right="5" top="5" bottom="5" />
-      </BackgroundInsets>
-      <TileSize>
-        <AbsValue val="16" />
-      </TileSize>
-      <EdgeSize>
-        <AbsValue val="16" />
-      </EdgeSize>
-    </Backdrop>
-
     <Layers>
       <Layer level="ARTWORK">
         <FontString inherits="GameFontDisableSmall" text="PRESS_TAB">


### PR DESCRIPTION
The Backdrop is not available anymore in the newest SoD client 1.15.5, assuming this is in all clients too.

```
ItemAutocomplete/Ui/ButtonMenu.xml:23 Unrecognized XML: Backdrop
ItemAutocomplete/Ui/ButtonMenu.xml:25 Unrecognized XML: AbsInset
ItemAutocomplete/Ui/ButtonMenu.xml:24 Unrecognized XML: BackgroundInsets
```

The Backdrop is set in LUA ([here](https://github.com/darfink/ItemAutocomplete/blob/a91d3d279386c534086788a6ebff896e63e93017/Ui/ButtonMenu.lua#L8-L15)) anyway.